### PR TITLE
feat: End game when learning score is zero

### DIFF
--- a/playablead.html
+++ b/playablead.html
@@ -7923,6 +7923,10 @@
             if (state.equity < state.achievementStats.minEquity) state.achievementStats.minEquity = state.equity;
             
             checkEquityAchievements();
+
+            if (state.equity <= 0 && !state.isEnded) {
+                endGame();
+            }
         }
 
         // ----------------------------------------------------------------------------


### PR DESCRIPTION
This commit adds a check in the `updateAccount` function to end the game if the `state.equity` (learning score) drops to 0 or below.