### PR TITLE
fix: Start simulation from the first candle

### DIFF
--- a/playablead.html
+++ b/playablead.html
@@ -6765,7 +6765,7 @@
             
             const initialVisibleCandles = calculateVisibleCandles();
             // Start with some history visible
-            state.currentIndex = Math.min(Math.floor(initialVisibleCandles * 0.8), state.gameData.length - 1);
+            state.currentIndex = 0;
             
             updateDailyStats();
             state.current7DayRange = calculate7DayRange();


### PR DESCRIPTION
This commit addresses user feedback to start the simulation from the very beginning of the data set.

The `startGame` function is modified to initialize the chart's current index to 0, ensuring the simulation begins with the first candle.